### PR TITLE
Not delete tasks completions on update task

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "ru.olegivo.repeatodo.android"
         minSdk = 26
         targetSdk = 33
-        versionCode = 3
-        versionName = "0.3"
+        versionCode = 4
+        versionName = "0.4"
     }
     buildTypes {
         getByName("release") {

--- a/shared/src/commonMain/kotlin/ru/olegivo/repeatodo/db/LocalTasksDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/ru/olegivo/repeatodo/db/LocalTasksDataSourceImpl.kt
@@ -51,7 +51,19 @@ class LocalTasksDataSourceImpl(
 
     override suspend fun save(task: Task) {
         withContext(dispatchersProvider.io) {
-            db.taskQueries.saveTask(task.toDb())
+            if (db.taskQueries.isTaskExists(task.uuid).executeAsOne()) {
+                with(task) {
+                    db.taskQueries.updateTask(
+                        title = title,
+                        daysPeriodicity = daysPeriodicity,
+                        priority = priority,
+                        toDoListUuid = toDoListUuid,
+                        uuid = uuid
+                    )
+                }
+            } else {
+                db.taskQueries.addTask(task.toDb())
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/ru/olegivo/repeatodo/db/LocalToDoListsDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/ru/olegivo/repeatodo/db/LocalToDoListsDataSourceImpl.kt
@@ -40,7 +40,18 @@ class LocalToDoListsDataSourceImpl(
 
     override suspend fun save(toDoList: ToDoList.Custom) {
         withContext(dispatchersProvider.io) {
-            db.toDoListQueries.saveToDoList(toDoList.toDb())
+            db.transaction {
+                if (db.toDoListQueries.isToDoListExists(toDoList.uuid).executeAsOne()) {
+                    with(toDoList) {
+                        db.toDoListQueries.updateToDoList(
+                            title = title,
+                            uuid = uuid
+                        )
+                    }
+                } else {
+                    db.toDoListQueries.addToDoList(toDoList.toDb())
+                }
+            }
         }
     }
 

--- a/shared/src/commonMain/sqldelight/ru/olegivo/repeatodo/db/Task.sq
+++ b/shared/src/commonMain/sqldelight/ru/olegivo/repeatodo/db/Task.sq
@@ -41,9 +41,25 @@ SELECT
 FROM
     taskView;
 
-saveTask:
-INSERT OR REPLACE INTO Task
+isTaskExists:
+SELECT EXISTS(
+    SELECT 1 FROM Task
+    WHERE uuid = :uuid
+)
+;
+
+addTask:
+INSERT INTO Task
 VALUES ?;
+
+updateTask:
+UPDATE Task SET
+    title = :title,
+    daysPeriodicity = :daysPeriodicity,
+    priority = :priority,
+    toDoListUuid = :toDoListUuid
+WHERE uuid = :uuid
+;
 
 getTask:
 SELECT

--- a/shared/src/commonMain/sqldelight/ru/olegivo/repeatodo/db/ToDoList.sq
+++ b/shared/src/commonMain/sqldelight/ru/olegivo/repeatodo/db/ToDoList.sq
@@ -15,9 +15,22 @@ SELECT
 FROM ToDoList
 ;
 
-saveToDoList:
-INSERT OR REPLACE INTO ToDoList
+isToDoListExists:
+SELECT EXISTS(
+    SELECT 1 FROM ToDoList
+    WHERE uuid = :uuid AND isPredefined = 0
+)
+;
+
+addToDoList:
+INSERT INTO ToDoList
 VALUES ?;
+
+updateToDoList:
+UPDATE ToDoList SET
+    title = :title
+WHERE uuid = :uuid AND isPredefined = 0
+;
 
 deleteToDoList:
 DELETE FROM ToDoList


### PR DESCRIPTION
Use separated `INSERT` and `UPDATE` instead of `INSERT OR REPLACE`

Cause `INSERT OR REPLACE` leads to deletion of the record and so deletion of all related records by cascade deletion